### PR TITLE
Revert to using vanilla alpine with openjdk8 testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
-FROM frolvlad/alpine-oraclejdk8:slim
+FROM alpine:3.2
 ADD pom.xml /
 ADD http://git.svc.ft.com/projects/FP/repos/ft-toolbox/browse/files/settings.xml?at=ca798f77a173aa200ec7a5382a2126133c44d725&raw /root/.m2/settings.xml
-RUN apk --update add tar ca-certificates \
+RUN echo "@testing http://nl.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories \
+  && apk --update add tar ca-certificates openjdk8@testing \
   && wget http://www.webhostingjams.com/mirror/apache/maven/maven-3/3.3.3/binaries/apache-maven-3.3.3-bin.tar.gz \
   && tar xf apache-maven-3.3.3-bin.tar.gz \
   && ln -sf /apache-maven-3.3.3/bin/mvn /usr/bin/mvn \


### PR DESCRIPTION
Replacing this:
https://github.com/frol/docker-alpine-oraclejdk8/blob/master/Dockerfile

With openjdk8 from testing.